### PR TITLE
#34 correction to instaOAuth.R

### DIFF
--- a/instaR/R/instaOAuth.R
+++ b/instaR/R/instaOAuth.R
@@ -67,7 +67,7 @@ instaOAuth <- function(app_id, app_secret, scope="basic"){
     if (packageVersion('httr') <= "0.2"){
         insta_token <- httr::oauth2.0_token(instagram, myapp, scope=scope)
         token <- httr::sign_oauth2.0(insta_token$access_token)
-        if (httr::GET("https://api.instagram.com/v1/users/self/feed?count=1", 
+        if (httr::GET("https://api.instagram.com/v1/users/self/?", 
             config=token)$status==200){
             message("Authentication successful.")
         }
@@ -76,8 +76,7 @@ instaOAuth <- function(app_id, app_secret, scope="basic"){
     ## httr 0.3 to 0.6.1
     if (packageVersion('httr') > "0.2" & packageVersion('httr') <= "0.6.1"){
         token <- httr::oauth2.0_token(instagram, myapp, cache=FALSE, scope=scope)
-        if (httr::GET(paste0("https://api.instagram.com/v1/users/self/feed?count=1", 
-                "&access_token=", 
+        if (httr::GET(paste0("https://api.instagram.com/v1/users/self/?access_token=",
                 token$credentials$access_token))$status==200){
             message("Authentication successful.")
         }   
@@ -85,10 +84,9 @@ instaOAuth <- function(app_id, app_secret, scope="basic"){
     
     ## current httr version
     if (packageVersion('httr') > "0.6.1"){
-        Sys.setenv("HTTR_SERVER_PORT" = "1410/")
+        Sys.setenv("HTTR_SERVER_PORT" = "1410")
         token <- httr::oauth2.0_token(instagram, myapp, cache=FALSE, scope=scope)
-        if (httr::GET(paste0("https://api.instagram.com/v1/users/self/feed?count=1", 
-                "&access_token=", 
+        if (httr::GET(paste0("https://api.instagram.com/v1/users/self/?access_token=", 
                 token$credentials$access_token))$status==200){
             message("Authentication successful.")
         }  


### PR DESCRIPTION
changed testing URL (found in API's documentation)
for recent httr version : removed '/' into HTTR_SERVER_PORT as it is
showed in hadley/httr/R/oauth-listener.r
